### PR TITLE
Agent updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.swp
 .settings
 settings-local.py
+.idea
+.tox
+*.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+install:
+  - pip install tox 
+script:
+  - tox
+env:
+  - TOXENV=pep8

--- a/selena_agent/__init__.py
+++ b/selena_agent/__init__.py
@@ -1,1 +1,1 @@
-VERSION = (1, 0, 3)
+VERSION = (1, 0, 4)

--- a/selena_agent/monitor.py
+++ b/selena_agent/monitor.py
@@ -125,7 +125,7 @@ def _do_request(url, useragent, timeout=30, referer=None, auth={},
         result.update({
             'error': str(e[1]),
         })
-    except:
+    except Exception:
         result.update({
             'error': str(sys.exc_info()),
         })

--- a/selena_agent/rqworker.py
+++ b/selena_agent/rqworker.py
@@ -31,8 +31,7 @@ def main():
         db=settings.REDIS_CONNECTION.get('DB'),
         password=settings.REDIS_CONNECTION.get('PASSWORD'),
     )
-    stopped = False
-    while True and not stopped:
+    while True:
         try:
             with Connection(redis_connection):
                 worker = Worker(Queue(name=settings.QUEUE_NAME))

--- a/selena_agent/rqworker.py
+++ b/selena_agent/rqworker.py
@@ -6,26 +6,45 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
+
+from time import sleep
+
 from redis import Redis
+from redis.exceptions import ConnectionError
 from rq import Queue, Connection, Worker
 
 from selena_agent import settings
 from selena_agent import VERSION
 
 
+logging.config.dictConfig(settings.LOGGING)
+logger = logging.getLogger(__name__)
+
+
 def main():
+    logger.info("Selena Agent, version %s" % ".".join(
+        str(num) for num in VERSION))
     redis_connection = Redis(
         host=settings.REDIS_CONNECTION.get('HOST'),
         port=settings.REDIS_CONNECTION.get('PORT'),
         db=settings.REDIS_CONNECTION.get('DB'),
         password=settings.REDIS_CONNECTION.get('PASSWORD'),
     )
-    with Connection(redis_connection):
-        print("Selena Agent, version %s" % ".".join(
-            str(num) for num in VERSION,
-        ))
-        worker = Worker(Queue(name=settings.QUEUE_NAME))
-        worker.work()
+    stopped = False
+    while True and not stopped:
+        try:
+            with Connection(redis_connection):
+                worker = Worker(Queue(name=settings.QUEUE_NAME))
+                worker.work()
+
+                # When the worker receives a stop signal, we can easily exit
+                # the loop
+                break
+        except ConnectionError as e:
+            logger.error(
+                "Error when connecting to Redis, retrying: {}".format(e))
+            sleep(10)
 
 
 if __name__ == '__main__':

--- a/selena_agent/settings.py
+++ b/selena_agent/settings.py
@@ -20,6 +20,29 @@ QUEUE_NAME = None
 
 SALT = None
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'verbose': {
+            'format': '%(asctime)s %(levelname)s %(module)s line:%(lineno)d: %(message)s'
+        },
+    },
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+            'formatter': 'verbose',
+        },
+    },
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': 'DEBUG',
+        },
+    },
+}
+
 local_settings = '%s%ssettings-local.py' % (
     os.path.realpath(os.path.dirname(__file__)),
     os.path.sep,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = pep8
+minversion = 1.6
+skipsdist = True
+
+[testenv:pep8]
+# Install bounded pep8/pyflakes first, then let flake8 install
+deps = pep8==1.4.5
+       pyflakes==0.7.2
+       flake8==2.0
+       hacking>=0.8.0,<0.9
+commands =
+    flake8
+
+[flake8]
+builtins = _
+exclude =  .venv,env,.git,.tox,dist,doc,*lib/python*,*egg,build,settings.py,settings-local.py,settings-tests.py,*migrations*
+# E127 continuation line over-indented for visual indent
+# E128 continuation line under-indented for visual indent
+# H102 Apache 2.0 license header not found
+# H701 empty localization string
+# H306 imports not in alphabetical order
+# H301 one import per line
+# H802 git commit title should be under 50 chars
+ignore = E127,E128,H102,H301,H306,H701,H802


### PR DESCRIPTION
- agent shouldn't die when redis is unavailable
- at least do some basic PEP8 tests
- add configurable logging instead of print statements
