### PR TITLE
Encode POST and GET parameters in utf-8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 .settings
 settings-local.py
+selena_agent.egg-info/

--- a/selena_agent/monitor.py
+++ b/selena_agent/monitor.py
@@ -33,8 +33,8 @@ AUTH_METHOD_BY_ID = {
 def _get_post_data_as_list(post_string):
     return [
         tuple(element.encode('utf-8')
-            for element in segment.split('='))
-                for segment in post_string.split("&")
+              for element in segment.split('=')
+              ) for segment in post_string.split("&")
     ]
 
 

--- a/selena_agent/monitor.py
+++ b/selena_agent/monitor.py
@@ -33,8 +33,8 @@ AUTH_METHOD_BY_ID = {
 def _get_post_data_as_list(post_string):
     return [
         tuple(element.encode('utf-8')
-              for element in segment.split('='))
-                    for segment in post_string.split("&")
+            for element in segment.split('='))
+                for segment in post_string.split("&")
     ]
 
 

--- a/selena_agent/monitor.py
+++ b/selena_agent/monitor.py
@@ -32,7 +32,9 @@ AUTH_METHOD_BY_ID = {
 
 def _get_post_data_as_list(post_string):
     return [
-        tuple( element.encode('utf-8') for element in segment.split('=')) for segment in post_string.split("&")
+        tuple(element.encode('utf-8')
+              for element in segment.split('='))
+                    for segment in post_string.split("&")
     ]
 
 

--- a/selena_agent/monitor.py
+++ b/selena_agent/monitor.py
@@ -32,7 +32,7 @@ AUTH_METHOD_BY_ID = {
 
 def _get_post_data_as_list(post_string):
     return [
-        tuple(segment.split('=')) for segment in post_string.split("&")
+        tuple( element.encode('utf-8') for element in segment.split('=')) for segment in post_string.split("&")
     ]
 
 


### PR DESCRIPTION
Propose a change to selena-agent which encodes all URL parameters in GET or POST request in 'utf-8'. Without the change some controllers (specially which supports only POST request) do not accept HTTP request
This change follows appriopriate changes in selena project.
